### PR TITLE
Fix factorial edge case

### DIFF
--- a/Sources/MathParser/Utils.swift
+++ b/Sources/MathParser/Utils.swift
@@ -3,7 +3,11 @@
 import Foundation
 
 @inlinable
-func factorial(_ n: Double) -> Double { (1...Int(n)).map(Double.init).reduce(1.0, *) }
+func factorial(_ n: Double) -> Double {
+  guard n >= 0 else { return .nan }
+  guard n >= 1 else { return 1.0 }
+  return (1...Int(n)).map(Double.init).reduce(1.0, *)
+}
 
 @inlinable
 func multiply(lhs: Token, rhs: Token) -> Token { Token.reducer(lhs: lhs, rhs: rhs, op: (*), name: "*") }


### PR DESCRIPTION
## Summary
- prevent factorial() from crashing on non-positive inputs

## Testing
- `swift build` *(fails: unable to clone dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683f482bff648325b6e60095d7c3044f